### PR TITLE
Add support for also hashing link and network layer information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-go.mod
-go.sum
 can-i-use-afpacket-fanout

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+go.mod
+go.sum
+can-i-use-afpacket-fanout

--- a/README.md
+++ b/README.md
@@ -2,27 +2,30 @@
 
 ## Background
 
-The linux kernel has a feature for efficiently capturing packets called afpacket.
+The Linux kernel has a feature for efficiently capturing packets called afpacket.
 
-A related feature,  `fanout groups`, exists so that you can capture from N proccesses or threads at the
+A related feature,  `fanout groups`, exists so that you can capture from N processes or threads at the
 same time, and each thread will see 1/Nth of the traffic.  For stateful
 applications that perform stream reassembly, instead of a simple round robin distribution the packets need to
 be hashed according to their 5 tuple.  To further complicate the issue, the hash function
 needs to be symmetrical so that a packet from HostA to HostB is hashed to the
-same proccess as the packet from HostB to HostA.  This feature is known as PACKET\_FANOUT\_HASH
+same process as the packet from HostB to HostA. This feature is known as PACKET\_FANOUT\_HASH
 
-Unfortnately, some versions of the linux kernel are broken and do not properly
-implement the symmetric hash.  [This issue has been
+Unfortunately, some versions of the Linux kernel are broken and do not properly
+implement the symmetric hash. [This issue has been
 fixed](https://git.kernel.org/cgit/linux/kernel/git/davem/net-next.git/commit/?id=eb70db8756717b90c01ccc765fdefc4dd969fc74),
 but the buggy code made its way into various distribution kernels.
 
 It's not easy to know just by looking at a kernel version whether or not it
 will work properly.
 
+Furthermore, in some cases -- like, for example, with MPLS traffic -- afpacket fanout might not do the balancing
+as you expect.
+
 `can-i-use-afpacket-fanout` is a tool that runs multiple threads in a fanout group and checks to
 see if flows are routed to the appropriate workers.  If it sees a flow
 on two different workers, or the reverse flow on a different worker, it
-will log a FAILure.
+will log a Failure.
 
 ## Install
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ var (
 	//skipInitial is used to skip packets that are delivered before the kernel fully sets up the load balancing
 	//between all the workers
 	skipInitial int
+	includeNetworkLayer bool
+	dumpNetworkLayerInformation bool
 	wg          sync.WaitGroup
 )
 
@@ -30,12 +32,15 @@ func init() {
 	flag.StringVar(&iface, "interface", "eth0", "Interface")
 	flag.IntVar(&statusInterval, "statusinterval", 500, "How many packets before each status update")
 	flag.IntVar(&skipInitial, "skipinitial", 100, "How many packets to skip before collecting data")
+	flag.BoolVar(&includeNetworkLayer, "includenetworklayer", false, "Set this flag to include the link and network layer protocols in the hash calculation")
+	flag.BoolVar(&dumpNetworkLayerInformation, "dumpnetworklayerinformation", false, "Set this flag to include the network layer information in the per-node output. Implies includenetworklayer")
 	flag.Parse()
 }
 
 type FiveTuple struct {
 	proto                  string
 	src, sport, dst, dport string
+	layerNames             string
 }
 
 type WorkerFlow struct {
@@ -68,6 +73,21 @@ func getFiveTuple(p gopacket.Packet) (FiveTuple, error) {
 		flow.sport = sport.String()
 		flow.dport = dport.String()
 	}
+
+	if includeNetworkLayer {
+		for _, layer := range p.Layers() {
+			// stop at the transport layer
+			if tl != nil && layer == tl {
+				break
+			}
+			if len(flow.layerNames) == 0 {
+				flow.layerNames = layer.LayerType().String()
+			} else {
+				flow.layerNames += ", " + layer.LayerType().String()
+			}
+		}
+	}
+
 	return flow, nil
 }
 
@@ -106,12 +126,17 @@ func worker(id int, flowchan chan WorkerFlow) {
 
 func main() {
 
+	if dumpNetworkLayerInformation {
+		includeNetworkLayer = true
+	}
+
 	flows := make(chan WorkerFlow, workerCount)
 
 	flowMap := make(map[FiveTuple]int)
 	failedFlowMap := make(map[FiveTuple]bool)
 	successFlowMap := make(map[FiveTuple]bool)
 	workerFlowCounts := make(map[int]int)
+	workerProtocolCounts := make(map[int]map[string]int)
 
 	wg.Add(workerCount)
 	for w := 0; w < workerCount; w++ {
@@ -125,12 +150,23 @@ func main() {
 	for workerflow := range flows {
 		s.packets++
 
-		//Check if this flow was seen before, and if so, on the same worker
+		// Check if this flow was seen before, and if so, on the same worker
 		flow := workerflow.flow
 		worker, existed := flowMap[flow]
 		if !existed {
 			flowMap[flow] = workerflow.workerID
 			workerFlowCounts[workerflow.workerID]++
+
+			if dumpNetworkLayerInformation {
+				// let's also do a protocol count
+				protocols, ok := workerProtocolCounts[workerflow.workerID]
+				if !ok {
+					protocols = make(map[string]int)
+					workerProtocolCounts[workerflow.workerID] = protocols
+				}
+				protocols[flow.layerNames]++
+			}
+
 		} else if worker != workerflow.workerID {
 			log.Printf("FAIL: saw flow %s on worker %d expected %d", flow, workerflow.workerID, worker)
 			failedFlowMap[flow] = true
@@ -143,8 +179,9 @@ func main() {
 			s.success++
 		}
 
+
 		//now check if the reverse flow was seen, and if so, on the same worker
-		reverseFlow := FiveTuple{flow.proto, flow.dst, flow.dport, flow.src, flow.sport}
+		reverseFlow := FiveTuple{flow.proto, flow.dst, flow.dport, flow.src, flow.sport, flow.layerNames}
 
 		worker, existed = flowMap[reverseFlow]
 		if !existed {
@@ -174,5 +211,10 @@ func main() {
 	log.Printf("Worker flow count distribution:")
 	for w := 0; w < workerCount; w++ {
 		log.Printf(" - worker=%d flows=%d", w, workerFlowCounts[w])
+		if dumpNetworkLayerInformation && workerFlowCounts[w] > 0 {
+			for proto, count := range workerProtocolCounts[w] {
+				log.Printf("   - protocol=%s flows=%d", proto, count)
+			}
+		}
 	}
 }


### PR DESCRIPTION
This commit adds two flags to can-i-use-afpacket-fanout:

-includenetworklayer includes information about the link and network
layers into the hash that is used to determine if packets end up on the
correct thread.

This can be useful if you have, e.g., MPLS wrapped packets on your
network. If you see packets twice, once encapsulated in MPLS and once
outside of MPLS, can-I-use-afpacket will probably complain about
mismatched packets with this option, because it only looks at the IP
addresses and ports.

-dumpnetworklayerinformation outputs information about the number of
flows that were seen with each link and networklayer on each thread.
This can be useful to diagnose if a single thread is being overloaded,
e.g. with all MPLS packets.

Example output:

2021/04/28 16:57:04  - worker=11 flows=840244
2021/04/28 16:57:04    - protocol=Ethernet, IPv4, IPv6, ICMPv6, ICMPv6Echo flows=1
2021/04/28 16:57:04    - protocol=Ethernet, IPv4 flows=14954
2021/04/28 16:57:04    - protocol=Ethernet, MPLS, IPv4, ICMPv4, Payload flows=22907
2021/04/28 16:57:04    - protocol=Ethernet, MPLS, IPv4, Fragment flows=41